### PR TITLE
Remove the file_put_contents() calls before the assertSame()'s

### DIFF
--- a/tests/QrCode/Output/HtmlTest.php
+++ b/tests/QrCode/Output/HtmlTest.php
@@ -19,7 +19,6 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
 		$data = $output->output($code);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-L.html';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 
 		$code->disableBorder();
@@ -27,7 +26,6 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
 		$data = $output->output($code);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-L-noborder.html';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 
 		$code = new QrCode('LOREM IPSUM 2019', QrCode::ERROR_CORRECTION_QUARTILE);
@@ -35,7 +33,6 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
 		$data = $output->output($code);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-Q.html';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 	}
 }

--- a/tests/QrCode/Output/PngTest.php
+++ b/tests/QrCode/Output/PngTest.php
@@ -19,13 +19,11 @@ class PngTest extends \PHPUnit\Framework\TestCase
 		$data = $output->output($code);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-L-100.png';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 
 		$data = $output->output($code, 250);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-L-250.png';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 
 		$code->disableBorder();
@@ -33,7 +31,6 @@ class PngTest extends \PHPUnit\Framework\TestCase
 		$data = $output->output($code, 250);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-L-250-noborder.png';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 
 		$code = new QrCode('LOREM IPSUM 2019', QrCode::ERROR_CORRECTION_QUARTILE);
@@ -41,13 +38,11 @@ class PngTest extends \PHPUnit\Framework\TestCase
 		$data = $output->output($code);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-Q-100.png';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 
 		$data = $output->output($code, 250);
 
 		$filename = __DIR__ . '/../../reference/LOREM-IPSUM-2019-Q-250.png';
-		file_put_contents($filename, $data);
 		$this->assertSame($data, file_get_contents($filename));
 	}
 }


### PR DESCRIPTION
The PngTest and HtmlTest does not test if the output is correct.

Although you have assert that the generated (binary) string is the same as in the reference directory... you have a `file_put_content()` right in front of it... ;-)