### PR TITLE
Allow newer versions of paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 
 	"require": {
 		"php": "^5.6 || ^7.0 || ^8.0",
-		"paragonie/random_compat": "^1.4|^2.0|9.99.99"
+		"paragonie/random_compat": "^1.4|^2.0|^9.99.99"
 	},
 
 	"require-dev": {


### PR DESCRIPTION
Allows to use paragonie/random_compat version 9.99.100 compatible with PHP 8.

Fixes #6 