### PR TITLE
Remove '<?xml version="1.0"?>' from the XML string of the SVG output

### DIFF
--- a/src/Output/Svg.php
+++ b/src/Output/Svg.php
@@ -136,7 +136,7 @@ class Svg
 			}
 		}
 
-		return $svg->asXML();
+		return str_replace('<?xml version="1.0"?>', '', $svg->asXML());
 	}
 
 


### PR DESCRIPTION
When I insert the SVG QR code into my PDF file, like so:

```php
$qrCode = new QrCode($certQrCode);
$qrCodeOutput = new Output\Svg();
$mpdf->WriteHTML('<div style="position: absolute; top: 5px; right: 45px;">' . $qrCodeOutput->output($qrCode, 150, 'white', 'black') . '</div>');
```

the QR code is rendered with a visible text `<?xml version="1.0"?>` attached to it.