### PR TITLE
Remove error suppression to avoid undefined errors on PHP 8.1

### DIFF
--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -440,13 +440,14 @@ class QrCode
 
 			$flag = true;
 			while ($flag) {
+				$wordDataValue = isset($this->wordData[$wordCount]) ? $this->wordData[$wordCount] : null;
 				if ($remainingBit > $bufferBit) {
-					$this->wordData[$wordCount] = ((@$this->wordData[$wordCount] << $bufferBit) | $bufferVal);
+					$this->wordData[$wordCount] = (($wordDataValue << $bufferBit) | $bufferVal);
 					$remainingBit -= $bufferBit;
 					$flag = false;
 				} else {
 					$bufferBit -= $remainingBit;
-					$this->wordData[$wordCount] = ((@$this->wordData[$wordCount] << $remainingBit) | ($bufferVal >> $bufferBit));
+					$this->wordData[$wordCount] = (($wordDataValue << $remainingBit) | ($bufferVal >> $bufferBit));
 					$wordCount++;
 
 					if ($bufferBit === 0) {

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -440,14 +440,14 @@ class QrCode
 
 			$flag = true;
 			while ($flag) {
-				$wordDataValue = isset($this->wordData[$wordCount]) ? $this->wordData[$wordCount] : null;
+				$this->wordData[$wordCount] = isset($this->wordData[$wordCount]) ? $this->wordData[$wordCount] : 0;
 				if ($remainingBit > $bufferBit) {
-					$this->wordData[$wordCount] = (($wordDataValue << $bufferBit) | $bufferVal);
+					$this->wordData[$wordCount] = (($this->wordData[$wordCount] << $bufferBit) | $bufferVal);
 					$remainingBit -= $bufferBit;
 					$flag = false;
 				} else {
 					$bufferBit -= $remainingBit;
-					$this->wordData[$wordCount] = (($wordDataValue << $remainingBit) | ($bufferVal >> $bufferBit));
+					$this->wordData[$wordCount] = (($this->wordData[$wordCount] << $remainingBit) | ($bufferVal >> $bufferBit));
 					$wordCount++;
 
 					if ($bufferBit === 0) {

--- a/tests/QrCode/QrCodeTest.php
+++ b/tests/QrCode/QrCodeTest.php
@@ -66,4 +66,10 @@ class QrCodeTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		new QrCode(base64_encode(random_bytes(1024 * 3)));
 	}
 
+    public function testUndefinedIndex()
+    {
+        $qr = new QrCode('1234567890123456.gov.bcb.pix0114028268660001815204000053039865406119.925802BR5912Clip Oba Oba6013Monten Matriz62120508v10173176304F297');
+        $this->assertInstanceOf(QrCode::class, $qr);
+    }
+
 }

--- a/tests/QrCode/QrCodeTest.php
+++ b/tests/QrCode/QrCodeTest.php
@@ -66,10 +66,11 @@ class QrCodeTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		new QrCode(base64_encode(random_bytes(1024 * 3)));
 	}
 
-    public function testUndefinedIndex()
-    {
-        $qr = new QrCode('1234567890123456.gov.bcb.pix0114028268660001815204000053039865406119.925802BR5912Clip Oba Oba6013Monten Matriz62120508v10173176304F297');
-        $this->assertInstanceOf(QrCode::class, $qr);
-    }
+	public function testUndefinedIndex()
+	{
+		$value = '1234567890123456.gov.bcb.pix0114028268660001815204000053039865406119.925802BR5912Clip Oba Oba6013Monten Matriz62120508v10173176304F297';
+		$qr = new QrCode($value);
+		$this->assertInstanceOf(QrCode::class, $qr);
+	}
 
 }


### PR DESCRIPTION
In php 8.1 we are getting an undefined index warning