### PR TITLE
Allow CMYK colors in Mpdf Output

### DIFF
--- a/src/Output/Mpdf.php
+++ b/src/Output/Mpdf.php
@@ -16,8 +16,8 @@ class Mpdf
 	 * @param float $x position X
 	 * @param float $y position Y
 	 * @param float $w QR code width
-	 * @param int[] $background RGB background color
-	 * @param int[] $color RGB foreground and border color
+	 * @param int[] $background RGB/CMYK background color
+	 * @param int[] $color RGB/CMYK foreground and border color
 	 */
 	public function output(QrCode $qrCode, MpdfObject $mpdf, $x, $y, $w, $background = [255, 255, 255], $color = [0, 0, 0])
 	{
@@ -25,8 +25,11 @@ class Mpdf
 		$qrSize = $qrCode->getQrSize();
 		$s = $size / $qrCode->getQrDimensions();
 
-		$mpdf->SetDrawColor($color[0], $color[1], $color[2]);
-		$mpdf->SetFillColor($background[0], $background[1], $background[2]);
+        $background = array_slice($background, 0, 4);
+        $color = array_slice($color, 0, 4);
+
+		$mpdf->SetDrawColor(...$color);
+		$mpdf->SetFillColor(...$background);
 
 		if ($qrCode->isBorderDisabled()) {
 			$minSize = 4;
@@ -38,7 +41,7 @@ class Mpdf
 			$mpdf->Rect($x, $y, $size, $size, 'FD');
 		}
 
-		$mpdf->SetFillColor($color[0], $color[1], $color[2]);
+		$mpdf->SetFillColor(...$color);
 
 		$final = $qrCode->getFinal();
 

--- a/src/Output/Mpdf.php
+++ b/src/Output/Mpdf.php
@@ -25,8 +25,8 @@ class Mpdf
 		$qrSize = $qrCode->getQrSize();
 		$s = $size / $qrCode->getQrDimensions();
 
-        $background = array_slice($background, 0, 4);
-        $color = array_slice($color, 0, 4);
+		$background = array_slice($background, 0, 4);
+		$color = array_slice($color, 0, 4);
 
 		$mpdf->SetDrawColor(...$color);
 		$mpdf->SetFillColor(...$background);

--- a/tests/QrCode/Output/MpdfTest.php
+++ b/tests/QrCode/Output/MpdfTest.php
@@ -75,6 +75,24 @@ class MpdfTest extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 		$output->output($code, $mpdf, 0, 0, 0);
 	}
 
+	public function testOutputCMYK() 
+	{
+		$color = [1,2,3,4];
+		$background = [5,6,7,8];
+
+		$code = new QrCode('LOREM IPSUM 2019', QrCode::ERROR_CORRECTION_QUARTILE);
+
+		$mpdf = Mockery::mock('Mpdf\Mpdf');
+
+		$mpdf->shouldReceive('SetDrawColor')->with(1,2,3,4)->once();
+		$mpdf->shouldReceive('SetFillColor')->with(1,2,3,4)->once();
+		$mpdf->shouldReceive('SetFillColor')->with(5,6,7,8)->once();
+		$mpdf->shouldReceive('Rect')->times(217);
+
+		$output = new Mpdf();
+		$output->output($code, $mpdf, 0, 0, 0, $background, $color);
+	}
+
 	protected function tear_down()
 	{
 		parent::tear_down();


### PR DESCRIPTION
This PR allows the Mpdf Output function to pass along an optional fourth argument to `SetDrawColor` and `SetFillColor`, so that CMYK colors can be used for the QR Code. 