### PR TITLE
Adding support for PHP 8.4 and 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           ini-values: error_reporting=-1
           
       - name: "Update dependencies"
-        if: "${{ matrix.php-versions >= '8.4' }}"
+        if: "${{ matrix.php-version >= '8.4' }}"
         run: |
           composer remove --dev mockery/mockery --no-interaction --no-progress 
           composer require --dev mockery/mockery --no-interaction --no-progress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,12 +48,6 @@ jobs:
           extensions: "mbstring, gd, bcmath, bz2"
           tools: composer:v2
           ini-values: error_reporting=-1
-          
-      - name: "Update dependencies"
-        if: "${{ matrix.php-version >= '8.4' }}"
-        run: |
-          composer remove --dev mockery/mockery --no-interaction --no-progress 
-          composer require --dev mockery/mockery --no-interaction --no-progress
       
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,13 @@ jobs:
           extensions: "mbstring, gd, bcmath, bz2"
           tools: composer:v2
           ini-values: error_reporting=-1
-
+          
+      - name: "Update dependencies"
+        if: "${{ matrix.php-versions >= '8.4' }}"
+        run: |
+          composer remove --dev mockery/mockery --no-interaction --no-progress 
+          composer require --dev mockery/mockery --no-interaction --no-progress
+      
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
+          - "8.5"
         operating-system: [ubuntu-latest, windows-latest]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^1.0",
-		"mockery/mockery": "^0.9.5",
+		"mockery/mockery": "^0.9.5 || ^1.0",
 		"squizlabs/php_codesniffer": "^3.4",
 		"tracy/tracy": "^2.5"
 	},

--- a/src/Output/Png.php
+++ b/src/Output/Png.php
@@ -57,7 +57,10 @@ class Png
 		$data = ob_get_contents();
 		ob_end_clean();
 
-		imagedestroy($im);
+		//This function has been DEPRECATED as of PHP 8.5.0
+		if (PHP_VERSION_ID < 80500) {
+			imagedestroy($im);
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
Hello!

Also fixing `Deprecated: Function imagedestroy() is deprecated since 8.5, as it has no effect since PHP 8.0 in /private/var/www/qrcode/src/Output/Png.php on line 60` warning.
